### PR TITLE
os.tmpDir() is deprecated. Use os.tmpdir() instead.

### DIFF
--- a/lib/temp.js
+++ b/lib/temp.js
@@ -5,7 +5,7 @@ var randomPath = require('random-path')
 var retry = require('./retry')
 var WriteStream = require('./write-stream')
 
-var tmpdir = os.tmpDir()
+var tmpdir = os.tmpdir()
 
 function open (template, flags, mode, cb) {
   switch (flags) {


### PR DESCRIPTION
`os.tmpDir()`  is deprecated, updated to use `os.tmpdir()`

Background: https://nodejs.org/api/os.html#os_os_tmpdir
In the docs it says `os.tmpdir()` has been in since 0.9, i guess lowercase and camelCase versions has been available since then?

```
(node:30541) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
```