### PR TITLE
Fix for path argument error.

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -10,5 +10,7 @@ export default class TempWriteStream extends WriteStream {
     const { fd, path } = openSync(template, flags, mode)
 
     super(path, { ...options, fd })
+    
+    this.path = path;
   }
 }


### PR DESCRIPTION
I was having this error on node version v17.0.0 on Windows 11. 

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received undefined
    at new ReadStream (node:internal/fs/streams:171:5)
    at Object.createReadStream (node:fs:2869:10)
    at handleRequest (file:///C:/Users/blake/Desktop/Development/Quizel/hub-backend/node_modules/multer/lib/middleware.js:23:22)
```
For some reason, the WritableStream path attribute is never set. 

Could have something to do with this. https://github.com/nodejs/node/blob/8a920185cc7a3a874e9442291f2a1506df7649cc/lib/internal/fs/streams.js#L315

Anyway, this a quick fix for that.