### PR TITLE
Fix vulnerable dependency `minimatch  <3.0.5` (Severity: high)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "mocha": "^10.3.0",
-    "standard": "^16.0.3"
+    "standard": "^17.1.0"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "random-path": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "^8.4.0",
+    "mocha": "^10.3.0",
     "standard": "^16.0.3"
   },
   "engines": {


### PR DESCRIPTION
Fixes #13

Vulnerability in minimatch  <3.0.5
Severity: high
minimatch ReDoS vulnerability - GHSA-f8q6-p94x-37v3